### PR TITLE
fix: moved all globals to rf2 table/namespace

### DIFF
--- a/RF2/CONFIRM/acc_cal.lua
+++ b/RF2/CONFIRM/acc_cal.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }
@@ -21,5 +21,5 @@ return {
     title  = "Accelerometer",
     labels = labels,
     fields = fields,
-    init   = assert(loadScript("/scripts/RF2/acc_cal.lua"))(),
+    init   = assert(rf2.loadScript("/scripts/RF2/acc_cal.lua"))(),
 }

--- a/RF2/MSP/common.lua
+++ b/RF2/MSP/common.lua
@@ -33,27 +33,27 @@ function mspProcessTxQ()
         payload[1] = payload[1] + MSP_STARTFLAG
     end
     local i = 2
-    while (i <= protocol.maxTxBufferSize) and mspTxIdx <= #mspTxBuf do
+    while (i <= rf2.protocol.maxTxBufferSize) and mspTxIdx <= #mspTxBuf do
         payload[i] = mspTxBuf[mspTxIdx]
         mspTxIdx = mspTxIdx + 1
         mspTxCRC = mspTxCRC ~ payload[i]
         i = i + 1
     end
-    if i <= protocol.maxTxBufferSize then
+    if i <= rf2.protocol.maxTxBufferSize then
         payload[i] = mspTxCRC
         i = i + 1
       -- zero fill
-        while i <= protocol.maxTxBufferSize do
+        while i <= rf2.protocol.maxTxBufferSize do
             payload[i] = 0
             i = i + 1
         end
-        protocol.mspSend(payload)
+        rf2.protocol.mspSend(payload)
         mspTxBuf = {}
         mspTxIdx = 1
         mspTxCRC = 0
         return false
     end
-    protocol.mspSend(payload)
+    rf2.protocol.mspSend(payload)
     return true
 end
 
@@ -105,12 +105,12 @@ local function mspReceivedReply(payload)
         mspStarted = false
         return nil
     end
-    while (idx <= protocol.maxRxBufferSize) and (#mspRxBuf < mspRxSize) do
+    while (idx <= rf2.protocol.maxRxBufferSize) and (#mspRxBuf < mspRxSize) do
         mspRxBuf[#mspRxBuf + 1] = payload[idx]
         mspRxCRC = mspRxCRC ~ payload[idx]
         idx = idx + 1
     end
-    if idx > protocol.maxRxBufferSize then
+    if idx > rf2.protocol.maxRxBufferSize then
 		--print("  mspReceivedReply:  payload continues into next frame.")
         -- Store the last sequence number so we can start there on the next continuation payload
         mspRemoteSeq = seq
@@ -129,9 +129,9 @@ local function mspReceivedReply(payload)
 end
 
 function mspPollReply()
-    local startTime = getTime()
-    while (getTime() - startTime < 5) do
-        local mspData = protocol.mspPoll()
+    local startTime = rf2.getTime()
+    while (rf2.getTime() - startTime < 5) do
+        local mspData = rf2.protocol.mspPoll()
         if mspData ~= nil and mspReceivedReply(mspData) then
             mspLastReq = 0
             return mspRxReq, mspRxBuf, mspRxError

--- a/RF2/MSP/crsf.lua
+++ b/RF2/MSP/crsf.lua
@@ -9,7 +9,7 @@ local CRSF_FRAMETYPE_MSP_WRITE         = 0x7C      -- write with 60 byte chunked
 
 local crsfMspCmd = 0
 
-protocol.mspSend = function(payload)
+rf2.protocol.mspSend = function(payload)
     local payloadOut = { CRSF_ADDRESS_BETAFLIGHT, CRSF_ADDRESS_RADIO_TRANSMITTER }
     for i=1, #(payload) do
         payloadOut[i+2] = payload[i]
@@ -17,17 +17,17 @@ protocol.mspSend = function(payload)
     return crsf.pushFrame(crsfMspCmd, payloadOut)
 end
 
-protocol.mspRead = function(cmd)
+rf2.protocol.mspRead = function(cmd)
     crsfMspCmd = CRSF_FRAMETYPE_MSP_REQ
     return mspSendRequest(cmd, {})
 end
 
-protocol.mspWrite = function(cmd, payload)
+rf2.protocol.mspWrite = function(cmd, payload)
     crsfMspCmd = CRSF_FRAMETYPE_MSP_WRITE
     return mspSendRequest(cmd, payload)
 end
 
-protocol.mspPoll = function()
+rf2.protocol.mspPoll = function()
     while true do
         local cmd, data = crsf.popFrame()
         if cmd == CRSF_FRAMETYPE_MSP_RESP and data[1] == CRSF_ADDRESS_RADIO_TRANSMITTER and data[2] == CRSF_ADDRESS_BETAFLIGHT then

--- a/RF2/MSP/sp.lua
+++ b/RF2/MSP/sp.lua
@@ -6,27 +6,27 @@ local REPLY_FRAME_ID   = 0x32
 
 local lastSensorId, lastFrameId, lastDataId, lastValue
 
-protocol.mspSend = function(payload)
+rf2.protocol.mspSend = function(payload)
     local dataId = payload[1] + (payload[2] <<8 )
     local value = 0
     for i = 3, #payload do
         value = value + (payload[i] << ((i - 3) * 8))
     end
-    return protocol.push(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
+    return rf2.protocol.push(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
 end
 
-protocol.mspRead = function(cmd)
+rf2.protocol.mspRead = function(cmd)
     return mspSendRequest(cmd, {})
 end
 
-protocol.mspWrite = function(cmd, payload)
+rf2.protocol.mspWrite = function(cmd, payload)
     return mspSendRequest(cmd, payload)
 end
 
 -- Discards duplicate data from lua input buffer
 local function smartPortTelemetryPop()
     while true do
-        local sensorId, frameId, dataId, value = sportTelemetryPop()
+        local sensorId, frameId, dataId, value = rf2.sportTelemetryPop()
         if not sensorId then
             return nil
         elseif (lastSensorId == sensorId) and (lastFrameId == frameId) and (lastDataId == dataId) and (lastValue == value) then
@@ -41,7 +41,7 @@ local function smartPortTelemetryPop()
     end
 end
 
-protocol.mspPoll = function()
+rf2.protocol.mspPoll = function()
     while true do
         local sensorId, frameId, dataId, value = smartPortTelemetryPop()
         if (sensorId == SMARTPORT_REMOTE_SENSOR_ID or sensorId == FPORT_REMOTE_SENSOR_ID) and frameId == REPLY_FRAME_ID then

--- a/RF2/PAGES/accelerometer.lua
+++ b/RF2/PAGES/accelerometer.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/copy_profiles.lua
+++ b/RF2/PAGES/copy_profiles.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/filters.lua
+++ b/RF2/PAGES/filters.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/governor.lua
+++ b/RF2/PAGES/governor.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/mixer.lua
+++ b/RF2/PAGES/mixer.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/pids.lua
+++ b/RF2/PAGES/pids.lua
@@ -1,11 +1,11 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local colSpacing = tableSpacing.col * 0.65
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/profile.lua
+++ b/RF2/PAGES/profile.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/profile_governor.lua
+++ b/RF2/PAGES/profile_governor.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/profile_rescue.lua
+++ b/RF2/PAGES/profile_rescue.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }

--- a/RF2/PAGES/rates.lua
+++ b/RF2/PAGES/rates.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }
@@ -82,7 +82,7 @@ return {
         end
     end,
     updateRatesType = function(self, applyDefaults)
-        local ratesTable = assert(loadScript("/scripts/RF2/RATETABLES/"..self.getRatesType(self)..".lua"))()
+        local ratesTable = assert(rf2.loadScript("/scripts/RF2/RATETABLES/"..self.getRatesType(self)..".lua"))()
         for i = 1, #ratesTable.labels do
             self.labels[i].t = ratesTable.labels[i]
         end

--- a/RF2/PAGES/servos.lua
+++ b/RF2/PAGES/servos.lua
@@ -1,10 +1,10 @@
-local template = assert(loadScript(radio.template))()
+local template = assert(rf2.loadScript(rf2.radio.template))()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
 local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
-local yMinLim = radio.yMinLimit
+local yMinLim = rf2.radio.yMinLimit
 local x = margin
 local y = yMinLim - lineSpacing
 local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }
@@ -39,10 +39,7 @@ return {
                 self.servoConfiguration[i][j] = self.values[1 + (i - 1) * 16 + j]
             end
         end
-        if rfglobals.lastChangedServo == nil then
-            rfglobals.lastChangedServo = 1
-        end
-        self.setValues(self, rfglobals.lastChangedServo)
+        self.setValues(self, rf2.lastChangedServo)
         self.minBytes = 1 + 16
     end,
     setValues = function(self, servoIndex)
@@ -53,8 +50,8 @@ return {
         end
     end,
     servoChanged = function(self)
-        rfglobals.lastChangedServo = self.values[1] + 1
-        self.setValues(self, rfglobals.lastChangedServo)
-        dataBindFields()
+        rf2.lastChangedServo = self.values[1] + 1
+        self.setValues(self, rf2.lastChangedServo)
+        rf2.dataBindFields()
     end
 }

--- a/RF2/acc_cal.lua
+++ b/RF2/acc_cal.lua
@@ -10,9 +10,9 @@ local function processMspReply(cmd,rx_buf,err)
 end
 
 local function accCal()
-    if not accCalibrated and (lastRunTS == 0 or lastRunTS + INTERVAL < getTime()) then
-        protocol.mspRead(MSP_ACC_CALIBRATION)
-        lastRunTS = getTime()
+    if not accCalibrated and (lastRunTS == 0 or lastRunTS + INTERVAL < rf2.getTime()) then
+        rf2.protocol.mspRead(MSP_ACC_CALIBRATION)
+        lastRunTS = rf2.getTime()
     end
 
     mspProcessTxQ()

--- a/RF2/api_version.lua
+++ b/RF2/api_version.lua
@@ -6,15 +6,15 @@ local INTERVAL = 50
 
 local function processMspReply(cmd,rx_buf,err)
     if cmd == MSP_API_VERSION and #rx_buf >= 3 and not err then
-        apiVersion = rx_buf[2] + rx_buf[3] / 100
+        rf2.apiVersion = rx_buf[2] + rx_buf[3] / 100
         apiVersionReceived = true
     end
 end
 
 local function getApiVersion()
-    if not apiVersionReceived and (lastRunTS == 0 or lastRunTS + INTERVAL < getTime()) then
-        protocol.mspRead(MSP_API_VERSION)
-        lastRunTS = getTime()
+    if not apiVersionReceived and (lastRunTS == 0 or lastRunTS + INTERVAL < rf2.getTime()) then
+        rf2.protocol.mspRead(MSP_API_VERSION)
+        lastRunTS = rf2.getTime()
     end
 
     mspProcessTxQ()

--- a/RF2/protocols.lua
+++ b/RF2/protocols.lua
@@ -3,7 +3,7 @@ local supportedProtocols =
     smartPort =
     {
         mspTransport    = "/scripts/RF2/MSP/sp.lua",
-        push            = sportTelemetryPush,
+        push            = rf2.sportTelemetryPush,
         maxTxBufferSize = 6,
         maxRxBufferSize = 6,
         saveMaxRetries  = 3,      -- originally 2

--- a/RF2/radios.lua
+++ b/RF2/radios.lua
@@ -1,4 +1,4 @@
-local LCD_W, LCD_H = getWindowSize()
+local LCD_W, LCD_H = rf2.getWindowSize()
 local resolution = LCD_W.."x"..LCD_H
 
 local supportedRadios =

--- a/RF2/ui_init.lua
+++ b/RF2/ui_init.lua
@@ -5,18 +5,18 @@ local SUPPORTED_API_VERSION = "12.06" -- see main/msp/msp_protocol.h
 
 local function init()
     --if true then return true end
-    if rf2_getRSSI() == 0 then
+    if rf2.getRSSI() == 0 then
         returnTable.t = "Waiting for connection"
     elseif not apiVersionReceived then
-        getApiVersion = getApiVersion or assert(loadScript("/scripts/RF2/api_version.lua"))()
+        getApiVersion = getApiVersion or assert(rf2.loadScript("/scripts/RF2/api_version.lua"))()
         returnTable.t = getApiVersion.t
         apiVersionReceived = getApiVersion.f()
         if apiVersionReceived then
             getApiVersion = nil
             collectgarbage()
         end
-    elseif tostring(apiVersion) ~= SUPPORTED_API_VERSION then -- work-around for comparing floats
-        returnTable.t = "This version of the Lua scripts ("..SUPPORTED_API_VERSION..")\ncan't be used with the selected model ("..tostring(apiVersion)..")."
+    elseif tostring(rf2.apiVersion) ~= SUPPORTED_API_VERSION then -- work-around for comparing floats
+        returnTable.t = "This version of the Lua scripts ("..SUPPORTED_API_VERSION..")\ncan't be used with the selected model ("..tostring(rf2.apiVersion)..")."
     else
         -- received correct API version, proceed
         return true


### PR DESCRIPTION
In Ethos several scripts can run at the same time. It appears that scripts can call functions in other scripts if they are global and have the same name. This can lead to unforeseen issues. To avoid this, all global variables and functions are moved into a `rf2` table (namespace).