### PR TITLE
Remove redundant loop - and hopefully fix timeout issue

### DIFF
--- a/rf2elrstelemetry/telemetry.lua
+++ b/rf2elrstelemetry/telemetry.lua
@@ -39,9 +39,9 @@ local function setTelemetryValue(uid, subid, instance, value, unit, dec, name, m
         end
     else
         if sensors['uid'][uid] then
-            if sensors['lastvalue'][uid] == nil or sensors['lastvalue'][uid] ~= value then
-                sensors['uid'][uid]:value(value)
-            end
+
+            sensors['uid'][uid]:value(value)
+
 
             -- detect if sensor has been deleted or is missing after initial creation
             if sensors['uid'][uid]:state() == false then


### PR DESCRIPTION
This is a potential fix for the alert on elrs telemetry.

Previous code had a check to only update value if data changed.   Removing loop means it updates on every pass.. so in theory will reset the timer in ethos - and avoid the alert.

Wider testing needed to confirm fix works.