### PR TITLE
Release sensor

### DIFF
--- a/RF2/main.lua
+++ b/RF2/main.lua
@@ -765,10 +765,15 @@ local function paint(widget)
     end
 end
 
+local function close()
+	rf2.sensor = nil    -- release sensor or other lua's cant use it
+	system.exit()
+end
+
 local icon = lcd.loadMask("/scripts/RF2/RF.png")
 
 local function init()
-    system.registerSystemTool({name=name, icon=icon, wakeup=wakeup, paint=paint, event=event})
+    system.registerSystemTool({name=name, icon=icon, wakeup=wakeup, paint=paint, event=event, close=close})
 end
 
 return { init = init }


### PR DESCRIPTION
This update tells the ethos lua to release the variable.

Doing this essentially 'cleans up' and means that other luas like rfsuite can then do a call the the msp sensor.
